### PR TITLE
update exit logic + gh tag action #patch

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -11,8 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Bump version and push tag
         if: ${{ github.event_name == 'push' }}
-        uses: anothrNick/github-tag-action@1.17.2
+        uses: anothrNick/github-tag-action@1.35.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
-          RELEASE_BRANCHES: main,release*

--- a/okv/okv.py
+++ b/okv/okv.py
@@ -63,13 +63,17 @@ def included_ok_schema(oktype):
 def composite_error_message(result, root_validation_error=None):
     results = []
     for given_result in result:
+        if given_result.isValid():
+            continue
         results.append(str(given_result))
         if root_validation_error:
             for error_result in root_validation_error.results:
                 for error in error_result.errors:
                     error_string = '\t{0}'.format(str(error))
                     results.append(error_string)
-    return '\n'.join(results)
+    if results:
+        return '\n'.join(results)
+    return None
 
 
 def _handle_error_exit(error_messages):


### PR DESCRIPTION
## Fixes

- Valid results were still being appended to error messages array

## Changes

- Update the tagging GitHub Action to latest version