### PR TITLE
Make GitHub Action friendlier for pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ This action uses an Open Knowledge Framework schema to validate your manifest su
 
 *Optional* How many cores to use. Default `"4"`.
 
+#### `file-restrictions`
+
+*Optional* For a given path or directory, only process these (space separated) files. Useful for pull requests. Default `""`.
+
 #### `ok`
 
 *Optional* Which Open Knowledge Framework schema to use for validation. Default [`"okh"`](./okv/schemas/okh.yaml).
@@ -33,11 +37,11 @@ This action uses an Open Knowledge Framework schema to validate your manifest su
 ### Example usage
 
 ```yaml
-uses: helpfulengineering/ok-validate@v0.0.1
+uses: helpfulengineering/ok-validate@v0.0.4
 ```
 
 ```yaml
-uses: helpfulengineering/ok-validate@v0.0.1
+uses: helpfulengineering/ok-validate@v0.0.4
 with:
   path: './some/path/to/file.yaml'
 ```

--- a/action.yaml
+++ b/action.yaml
@@ -9,6 +9,10 @@ inputs:
     description: 'How many cores to use'
     required: false
     default: '4'
+  file-restrictions:
+    description: 'For a given path or directory, only process these (space separated) files. Useful for pull requests.'
+    required: false
+    default: ''
   ok:
     description: 'Which preset Open Knowledge Framework schema to use for validation. Should be one of ("okh")'
     required: false
@@ -18,7 +22,7 @@ inputs:
     required: false
     default: 'pyyaml'
   path:
-    description: 'The path to your mainfest or manifests relative to your workspace'
+    description: 'The path to your manifest(s) relative to your workspace'
     required: true
     default: './'
   schema:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,18 +1,59 @@
 #!/bin/bash
-set -ex
+set -e
 
+if [ ! -z "${DEBUG}" ]; then set -x; fi
 if [ -z "${GITHUB_ACTIONS}" ]; then
     exec okv ${@}
 else
     strict_mode='--no-strict'
     if [ "${INPUT_STRICT}" = "true" ]; then strict_mode=''; fi
     INPUT_CPU_NUM="$(env | sed -n 's/^INPUT_CPU-NUM=\(.*\)/\1/p')"
+    INPUT_FILE_RESTRICTIONS="$(env | sed -n 's/^INPUT_FILE-RESTRICTIONS=\(.*\)/\1/p')"
     schema_flag="--ok=${INPUT_OK}"
     if [ ! -z "${INPUT_SCHEMA}" ]; then
         schema_flag="--schema=${INPUT_SCHEMA}"
     fi
-    output=$(okv ${schema_flag} --cpu-num=${INPUT_CPU_NUM} --parser=${INPUT_PARSER} ${strict_mode} -path=${INPUT_PATH})
-    result=$?
+    output=""
+    result="0"
+    set +e
+    if [ -z "${INPUT_FILE_RESTRICTIONS}" ]; then
+        output=$(okv ${schema_flag} --cpu-num=${INPUT_CPU_NUM} --parser=${INPUT_PARSER} ${strict_mode} -path=${INPUT_PATH})
+        result=$?
+        echo "${output}"
+    else
+        # INPUT_FILE_RESTRICTIONS is expected to be a space-separated array
+        # of files
+        file_arr=($INPUT_FILE_RESTRICTIONS)
+        for file in ${file_arr[@]}; do
+            # If an input path is also provided, it is expected to serve as an
+            # enforced prefix for each of the file restrictions. In the case
+            # of the pull request, this means that added and modified files
+            # must exist within a particular directory or match a file
+            if [[ ! -z "${INPUT_PATH}" ]] && [[ "${file}" != ${INPUT_PATH}* ]]; then
+                continue
+            fi
+            tmp_output=$(okv ${schema_flag} --cpu-num=${INPUT_CPU_NUM} --parser=${INPUT_PARSER} ${strict_mode} -path=${file})
+            tmp_result=$?
+            # Loop over all files before throwing non-zero exit below
+            if [ "${tmp_result}" == "0"  ]; then
+                continue
+            fi
+            if [ "${result}" == "0"  ]; then
+                result="$tmp_result"
+            fi
+            if [ -z "${output}" ]; then
+                output="${tmp_output}"
+                echo "${output}"
+            else
+                echo "----
+${tmp_output}"
+                output="${output}
+                ----
+${tmp_output}"
+            fi
+        done
+    fi
+    set -e
     echo "::set-output name=results::$(echo $output)"
     if [ "${result}" != "0" ]; then exit 1; fi
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,7 +29,10 @@ else
             # enforced prefix for each of the file restrictions. In the case
             # of the pull request, this means that added and modified files
             # must exist within a particular directory or match a file
-            if [[ ! -z "${INPUT_PATH}" ]] && [[ "${file}" != ${INPUT_PATH}* ]]; then
+            if [[ ! -z "${INPUT_PATH}" ]] && [[ "${file}" != ${INPUT_PATH}*.y*ml ]]; then
+                continue
+            fi
+            if [ ! -f "${file}" ]; then
                 continue
             fi
             tmp_output=$(okv ${schema_flag} --cpu-num=${INPUT_CPU_NUM} --parser=${INPUT_PARSER} ${strict_mode} -path=${file})


### PR DESCRIPTION
## Added

- `file-restrictions` option to allow for a space-separated list of files instead of iterating over all files in a given directory if not modified. So instead of failing a pull request because a legacy file is not compliant, only fail if a modified file is invalid. Can restrict this to a prefix/path. Will need to be modified in the future as default input `path` is `./` which wold make file matching invalid when combined with `file-restrictions`