### PR TITLE
.JPGs are valid

### DIFF
--- a/okv/schemas/okh.yaml
+++ b/okv/schemas/okh.yaml
@@ -40,7 +40,7 @@ contact: include('contact-kit', required=False) # currently listed as required,
 
 contributors: list(include('nonessential-contact'), required=False)                             # recommended
 
-image: regex('http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+((.gif)|(.png)|(.jpg)|(.jpeg))$', name="valid image url", required=False) 
+image: regex('http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+((.gif)|(.png)|(.jpg)|(.jpeg))$', name="valid image url", ignore_case=True, required=False) 
 version: str(required=False)                 # text
 
 development-stage: str(required=False)       # text


### PR DESCRIPTION
for some reason I didn't think to put an ignore_case in the image regex. fixed that. if we merge this it'll be better than telling many ppl that they just have to uncapitalize the end of their image url .